### PR TITLE
[wip] Use ci-tools that has been merged back into Zephyr

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -191,16 +191,13 @@ jobs:
               options: "--privileged=true --tty --net=bridge"
           script:
             - cd $(shipctl get_resource_state "main_repo_doc");
-            - git clone https://github.com/zephyrproject-rtos/ci-tools.git
-            - ci-tools/scripts/build-docs.sh
+            - scripts/ci/build-docs.sh
 
   - name: zephyr-checks
     type: runSh
     steps:
       - IN: github_token
       - IN: s3-token
-      - IN: ci_tools_check_repo
-        switch: off
       - IN: testing_repo
         showBuildStatus:  false
       - TASK:
@@ -215,7 +212,6 @@ jobs:
           script:
             - cd $(shipctl get_resource_state "testing_repo")
             - pip3 install west
-            - export CITOOLS=$(shipctl get_resource_state "ci_tools_check_repo")
             - git fetch origin pull/${TESTING_REPO_PULL_REQUEST}/head
             - git checkout -f FETCH_HEAD
             - export SHA=$(git rev-parse HEAD)
@@ -223,10 +219,10 @@ jobs:
             - git rebase origin/${TESTING_REPO_BASE_BRANCH};
             - source zephyr-env.sh
             - export COMMIT_RANGE=origin/${TESTING_REPO_BASE_BRANCH}..HEAD
-            - ${CITOOLS}/scripts/what_changed.py -r ${TESTING_REPO_REPO_FULL_NAME} -p ${TESTING_REPO_PULL_REQUEST} --commits ${COMMIT_RANGE}
-            - ${CITOOLS}/scripts/check_compliance.py -g -r ${TESTING_REPO_REPO_FULL_NAME} -s -S ${SHA}
+            - scripts/ci/what_changed.py -r ${TESTING_REPO_REPO_FULL_NAME} -p ${TESTING_REPO_PULL_REQUEST} --commits ${COMMIT_RANGE}
+            - scripts/ci/check_compliance.py -g -r ${TESTING_REPO_REPO_FULL_NAME} -s -S ${SHA}
             - echo "Building a Pull Request";
-            - ${CITOOLS}/scripts/check_compliance.py -e Documentation --commits ${COMMIT_RANGE} -g -p ${TESTING_REPO_PULL_REQUEST} -r ${TESTING_REPO_REPO_FULL_NAME} -S ${SHA} -o first_pass.xml
+            - scripts/ci/check_compliance.py -e Documentation --commits ${COMMIT_RANGE} -g -p ${TESTING_REPO_PULL_REQUEST} -r ${TESTING_REPO_REPO_FULL_NAME} -S ${SHA} -o first_pass.xml
             - echo "Building Documentation";
             - echo "Commit range:" ${COMMIT_RANGE}
             - >
@@ -240,9 +236,9 @@ jobs:
                 echo " => New documentation warnings/errors";
                 cp doc/_build/doc.warnings doc.warnings
               fi;
-            - ${CITOOLS}/scripts/check_compliance.py --commits ${COMMIT_RANGE} -g -p ${TESTING_REPO_PULL_REQUEST} -r ${TESTING_REPO_REPO_FULL_NAME} -S ${SHA} -m Documentation -o second_pass.xml
+            - scripts/ci/check_compliance.py --commits ${COMMIT_RANGE} -g -p ${TESTING_REPO_PULL_REQUEST} -r ${TESTING_REPO_REPO_FULL_NAME} -S ${SHA} -m Documentation -o second_pass.xml
             - export S3_PATH="s3://builds.zephyrproject.org/${TESTING_REPO_REPO_FULL_NAME}/${TESTING_REPO_PULL_REQUEST}";
-            - ${CITOOLS}/scripts/merge_junit.py first_pass.xml second_pass.xml > compliance.xml
+            - scripts/ci/merge_junit.py first_pass.xml second_pass.xml > compliance.xml
             - junit2html compliance.xml tests.html
             - mkdir -p ${TESTING_REPO_PULL_REQUEST}
             - cp *.html ${TESTING_REPO_PULL_REQUEST}
@@ -256,8 +252,6 @@ jobs:
     steps:
       - IN: github_token
       - IN: s3-token
-      - IN: ci_tools_check_repo
-        switch: off
       - IN: main_repo
         showBuildStatus:  false
       - TASK:
@@ -282,18 +276,17 @@ jobs:
             - west init -l zephyr || true
             - cd zephyr
             - west update
-            - export CITOOLS=$(west list ci-tools -f"{abspath:18}")
-            - sudo pip3 install -r ${CITOOLS}/requirements.txt
+            - sudo pip3 install -r scripts/ci/requirements.txt
             - source zephyr-env.sh
             - export COMMIT_RANGE=origin/${MAIN_REPO_BASE_BRANCH}..HEAD
-            - ${CITOOLS}/scripts/what_changed.py -r ${MAIN_REPO_REPO_FULL_NAME} -p ${MAIN_REPO_PULL_REQUEST} --commits ${COMMIT_RANGE}
-            - ${CITOOLS}/scripts/check_compliance.py -g -r ${MAIN_REPO_REPO_FULL_NAME} -s -S ${SHA}
+            - scripts/ci/what_changed.py -r ${MAIN_REPO_REPO_FULL_NAME} -p ${MAIN_REPO_PULL_REQUEST} --commits ${COMMIT_RANGE}
+            - scripts/ci/check_compliance.py -g -r ${MAIN_REPO_REPO_FULL_NAME} -s -S ${SHA}
             - echo "Building a Pull Request";
             - echo "COMMIT_RANGE:" ${COMMIT_RANGE}
             - echo "MAIN_REPO_PULL_REQUEST:" ${MAIN_REPO_PULL_REQUEST}
             - echo "MAIN_REPO_REPO_FULL_NAME:" ${MAIN_REPO_REPO_FULL_NAME}
             - echo "SHA:" ${SHA}
-            - ${CITOOLS}/scripts/check_compliance.py -e Documentation --commits ${COMMIT_RANGE} -g -p ${MAIN_REPO_PULL_REQUEST} -r ${MAIN_REPO_REPO_FULL_NAME} -S ${SHA} -o first_pass.xml || true
+            - scripts/ci/check_compliance.py -e Documentation --commits ${COMMIT_RANGE} -g -p ${MAIN_REPO_PULL_REQUEST} -r ${MAIN_REPO_REPO_FULL_NAME} -S ${SHA} -o first_pass.xml || true
             - cat /tmp/Kconfig.modules
             - west list --format={posixpath}
             - echo "Building Documentation";
@@ -308,10 +301,10 @@ jobs:
                 echo " => New documentation warnings/errors";
                 cp doc/_build/doc.warnings doc.warnings
               fi;
-            - ${CITOOLS}/scripts/check_compliance.py --commits ${COMMIT_RANGE} -g -p ${MAIN_REPO_PULL_REQUEST} -r ${MAIN_REPO_REPO_FULL_NAME} -S ${SHA} -m Documentation --previous-run first_pass.xml -o second_pass.xml || true
+            - scripts/ci/check_compliance.py --commits ${COMMIT_RANGE} -g -p ${MAIN_REPO_PULL_REQUEST} -r ${MAIN_REPO_REPO_FULL_NAME} -S ${SHA} -m Documentation --previous-run first_pass.xml -o second_pass.xml || true
             - >
               export S3_PATH="s3://builds.zephyrproject.org/${MAIN_REPO_REPO_FULL_NAME}/${MAIN_REPO_PULL_REQUEST}";
-              ${CITOOLS}/scripts/merge_junit.py first_pass.xml second_pass.xml > compliance.xml;
+              scripts/ci/merge_junit.py first_pass.xml second_pass.xml > compliance.xml;
               junit2html compliance.xml tests.html;
               mkdir -p ${MAIN_REPO_PULL_REQUEST};
               cp *.html ${MAIN_REPO_PULL_REQUEST};
@@ -320,45 +313,3 @@ jobs:
               fi;
               aws s3 cp s3://builds.zephyrproject.org/pr.html ${S3_PATH}/index.html;
               aws s3 sync ${MAIN_REPO_PULL_REQUEST} ${S3_PATH};
-
-  - name: zephyr-checks-tools
-    type: runSh
-    triggerMode: parallel
-    steps:
-      - IN: github_token
-      - IN: s3-token
-      - IN: ci_tools_repo
-        showBuildStatus:  false
-      - TASK:
-          name: tools_check
-          runtime:
-            container: true
-            options:
-              imageName: zephyrprojectrtos/ci
-              imageTag: v0.9.1
-              pull: true
-              options: "--privileged=true --tty --net=bridge"
-          script:
-            - cd $(shipctl get_resource_state "ci_tools_repo")
-            - export CITOOLS=$(shipctl get_resource_state "ci_tools_repo")
-            - sudo pip3 install -r ${CITOOLS}/requirements.txt
-            - git fetch origin pull/${CI_TOOLS_REPO_PULL_REQUEST}/head
-            - git checkout -f FETCH_HEAD
-            - export SHA=$(git rev-parse HEAD)
-            - git merge -q origin/${CI_TOOLS_REPO_BASE_BRANCH}
-            - git rebase origin/${CI_TOOLS_REPO_BASE_BRANCH};
-            - ${CITOOLS}/scripts/check_compliance.py -g -r ${CI_TOOLS_REPO_REPO_FULL_NAME} -s -S ${SHA}
-            - export COMMIT_RANGE=origin/${CI_TOOLS_REPO_BASE_BRANCH}..HEAD
-            - echo "Building a Pull Request";
-            - ${CITOOLS}/scripts/check_compliance.py -e Documentation --commits ${COMMIT_RANGE} -g -p ${CI_TOOLS_REPO_PULL_REQUEST} -r ${CI_TOOLS_REPO_REPO_FULL_NAME} -S ${SHA} -o first_pass.xml || true
-            - echo "Building Documentation";
-            - echo "Commit range:" ${COMMIT_RANGE}
-            - ${CITOOLS}/scripts/check_compliance.py --commits ${COMMIT_RANGE} -g -p ${CI_TOOLS_REPO_PULL_REQUEST} -r ${CI_TOOLS_REPO_REPO_FULL_NAME} -S ${SHA} -m Documentation --previous-run first_pass.xml -o second_pass.xml || true
-            - export S3_PATH="s3://builds.zephyrproject.org/${CI_TOOLS_REPO_REPO_FULL_NAME}/${CI_TOOLS_REPO_PULL_REQUEST}";
-            - ${CITOOLS}/scripts/merge_junit.py first_pass.xml second_pass.xml > compliance.xml
-            - junit2html compliance.xml tests.html
-            - mkdir -p ${CI_TOOLS_REPO_PULL_REQUEST}
-            - cp *.html ${CI_TOOLS_REPO_PULL_REQUEST}
-            - aws s3 cp s3://builds.zephyrproject.org/pr.html ${S3_PATH}/index.html
-            - aws s3 sync ${CI_TOOLS_REPO_PULL_REQUEST} ${S3_PATH}
-

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -64,26 +64,6 @@ resources:
           buildOnPullRequest: true
           buildOnCommit: true
 
-    - name: ci_tools_repo
-      type: gitRepo
-      integration: github
-      pointer:
-          sourceName: zephyrproject-rtos/ci-tools
-          branch: master
-          buildOnPullRequest: true
-          buildOnCommit: true
-
-    - name: ci_tools_check_repo
-      type: gitRepo
-      integration: github
-      pointer:
-          sourceName: zephyrproject-rtos/ci-tools
-          branches:
-            only:
-              - master
-          buildOnPullRequest: false
-          buildOnCommit: true
-
     - name: main_repo_all_prep
       type: gitRepo
       integration: github


### PR DESCRIPTION
Remove all references to the ci-tools repository and run the scripts in
scripts/ci/ in the main Zephyr repository directly.

Requires https://github.com/zephyrproject-rtos/zephyr/pull/20039 to go
in first.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>