### PR TITLE
update to ci image 0.9.2 for sdk 0.11.0-alpha

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -198,7 +198,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.9.1
+              imageTag: v0.10.1
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -223,7 +223,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.9.1
+              imageTag: v0.10.1
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -285,7 +285,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.9.1
+              imageTag: v0.10.1
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -357,7 +357,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.9.1
+              imageTag: v0.10.1
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:


### PR DESCRIPTION
Bump ci image to pull in 0.11.0-alpha5 SDK for testing purposes.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>