### PR TITLE
ci: bump docker image to 0.11.3

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -199,7 +199,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.11.2
+              imageTag: v0.11.3
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -224,7 +224,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.11.2
+              imageTag: v0.11.3
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -286,7 +286,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.11.2
+              imageTag: v0.11.3
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:
@@ -360,7 +360,7 @@ jobs:
             container: true
             options:
               imageName: zephyrprojectrtos/ci
-              imageTag: v0.11.2
+              imageTag: v0.11.3
               pull: true
               options: "--privileged=true --tty --net=bridge"
           script:


### PR DESCRIPTION
Keep in sync with main zephyr repo

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>