### PR TITLE
Fix zephyr-daily-doc for diffs in west versions

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -204,6 +204,8 @@ jobs:
               options: "--privileged=true --tty --net=bridge"
           script:
             - cd $(shipctl get_resource_state "main_repo_doc");
+            - west -V
+            - west init -l .
             - git clone https://github.com/zephyrproject-rtos/ci-tools.git
             - ci-tools/scripts/build-docs.sh
 


### PR DESCRIPTION
Add a 'west init' to deal with differences between west 0.6.3 and west
0.7.x.  Without this we end up failing with west 0.7.x

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>